### PR TITLE
Return sample rate with TTS audio

### DIFF
--- a/image_processor.py
+++ b/image_processor.py
@@ -49,7 +49,7 @@ def main():
     # Process the image
     process_image(manga_page)
 
-def process_image(image) -> List[Tuple[Image.Image, npt.NDArray]]:
+def process_image(image) -> List[Tuple[Image.Image, npt.NDArray, int]]:
 
     outputs = []
 
@@ -77,8 +77,8 @@ def process_image(image) -> List[Tuple[Image.Image, npt.NDArray]]:
 
             # character_description = IMAGE_MODEL.get_description_of_character_speaking(image, l)
             # print(f"Got description of character as: {character_description}")
-            tss_arr = TTS_ENGINE.tts_from_text(l, "")
-            outputs.append((cropped_image, tss_arr))
+            tss_arr, sample_rate = TTS_ENGINE.tts_from_text(l, "")
+            outputs.append((cropped_image, tss_arr, sample_rate))
             print(f'tts for audio {l}')
 
             # Save the cropped image
@@ -87,7 +87,7 @@ def process_image(image) -> List[Tuple[Image.Image, npt.NDArray]]:
 
             # Save the audio file
             audio_path = f'TEMP/audio_{i}_{j}.wav'
-            convert_np_array_to_wav(tss_arr, path_to_file=audio_path)
+            convert_np_array_to_wav(tss_arr, sample_rate, path_to_file=audio_path)
 
             # Save the transcripted lines
             text_path = f'TEMP/transcription_{i}_{j}.txt'

--- a/server.py
+++ b/server.py
@@ -18,7 +18,8 @@ stored_results = {}
 
 def process_image_job(key, file_data):
     """
-    Return a list of tuples: [(PIL.Image, np.array), ...].
+    Return a list of tuples: ``[(PIL.Image, np.ndarray, int), ...]`` where the
+    integer is the sample rate of the audio.
     For demo, we create 3 dummy (image, audio) pairs.
     """
     pil_img = Image.open(io.BytesIO(file_data)).convert("L").convert("RGB")
@@ -28,13 +29,13 @@ def process_image_job(key, file_data):
     # Convert each (PIL.Image, np.array) to raw bytes
     # so we can store them in memory without re-running the processing later.
     results_bytes = []
-    for (img_obj, audio_array) in results:
+    for (img_obj, audio_array, sample_rate) in results:
         # Convert image to PNG bytes
         img_buffer = io.BytesIO()
         img_obj.save(img_buffer, format="PNG")
         img_bytes = img_buffer.getvalue()
 
-        wav_bytes = convert_np_array_to_wav(audio_array)
+        wav_bytes = convert_np_array_to_wav(audio_array, sample_rate)
 
         results_bytes.append((img_bytes, wav_bytes))
 

--- a/test_providers.py
+++ b/test_providers.py
@@ -39,9 +39,9 @@ def test_tts_providers(text: str, providers=None) -> None:
         try:
             print(f"Testing TTS provider: {provider}")
             tts = TTS(provider=provider)
-            audio = tts.tts_from_text(text)
+            audio, sample_rate = tts.tts_from_text(text)
             wav_path = f"sample_files/{provider}_sample.wav"
-            convert_np_array_to_wav(audio, path_to_file=wav_path)
+            convert_np_array_to_wav(audio, sample_rate, path_to_file=wav_path)
             print(f"Output ({provider}) saved to {wav_path}")
         except Exception as e:
             print(f"Failed to use TTS provider '{provider}': {e}")

--- a/utils.py
+++ b/utils.py
@@ -435,15 +435,16 @@ def parse_transcript(input_string):
 
     return [l for l in parsed_list if len(l)>1]
 
-def convert_np_array_to_wav(audio_array, path_to_file=None):
-    # Convert audio array to WAV bytes
+def convert_np_array_to_wav(audio_array, sample_rate, path_to_file=None):
+    """Convert a numpy array to WAV bytes using the provided sample rate."""
     wav_buffer = io.BytesIO()
-    sample_rate = 44100
-    # Scale float array to int16
-    scaled = np.int16(audio_array / np.max(np.abs(audio_array)) * 32767)
+    if audio_array.size == 0:
+        scaled = np.array([], dtype=np.int16)
+    else:
+        scaled = np.int16(audio_array / np.max(np.abs(audio_array)) * 32767)
     wavfile.write(wav_buffer, sample_rate, scaled)
     wav_bytes = wav_buffer.getvalue()
-    
+
     if path_to_file:
         wavfile.write(path_to_file, sample_rate, scaled)
 


### PR DESCRIPTION
## Summary
- make Parler and Kokoro TTS return `(audio, sample_rate)`
- update conversion helper to accept a sample rate parameter
- propagate sample rate through image processing pipeline and server
- adjust provider tests

## Testing
- `python -m py_compile server.py image_processor.py utils.py inference/*.py test_providers.py`
- `python test_providers.py --provider parler` *(fails: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68616195e0a4832ca524761c91527a0d